### PR TITLE
On Android return the purchaseToken in the purchase details.

### DIFF
--- a/src/android/IabPurchase.java
+++ b/src/android/IabPurchase.java
@@ -125,6 +125,7 @@ public class IabPurchase {
         detailsJson.put("productId", getProductId());
         detailsJson.put("productType", getProductType());
         detailsJson.put("purchaseTime", getPurchaseTime());
+        detailsJson.put("purchaseToken", getPurchaseToken());
         detailsJson.put("purchaseId", getOrderId());
         detailsJson.put("quantity", getQuantity());
         detailsJson.put("verified", getPurchaseVerified());

--- a/www/billing-android.js
+++ b/www/billing-android.js
@@ -182,6 +182,7 @@ inAppPurchases.getPurchases = function(){
                     //productType: val.productType,
                     purchaseTime: val.purchaseTime,
                     purchaseId: val.purchaseId,
+                    purchaseToken: val.purchaseToken,
                     quantity: val.quantity,
                     verified: val.verified,
                     pending: val.pending,
@@ -203,6 +204,7 @@ inAppPurchases.restorePurchases = function(){
                 return {
                 productId: val.productId,
                 //productType: val.productType,
+                purchaseToken: val.purchaseToken,
                 purchaseTime: val.purchaseTime,
                 purchaseId: val.purchaseId,
                 quantity: val.quantity,
@@ -227,6 +229,7 @@ inAppPurchases.purchase = function (productId){
                 resolve({
                     productId: res.productId,
                     //productType: res.productType,
+                    purchaseToken: res.purchaseToken,
                     purchaseTime: res.purchaseTime,
                     purchaseId: res.purchaseId,
                     quantity: res.quantity,
@@ -248,6 +251,7 @@ inAppPurchases.completePurchase = function (productId, consume = false){
                 resolve({
                     productId: res.productId,
                     //productType: res.productType,
+                    purchaseToken: res.purchaseToken,
                     purchaseTime: res.purchaseTime,
                     purchaseId: res.purchaseId,
                     quantity: res.quantity,


### PR DESCRIPTION
Would be nice to get **purchaseToken** after the successful purchase or getPurchases() and store on the server-side.
The **purchaseToken**  can be used later to handle subscriptions.
Currently without the **purchaseToken** is impossible to do anything with subscriptions. 

https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptionsv2/get
https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.subscriptions

There is a small patch in the pull request which exposed the **purchaseToken**.